### PR TITLE
fix: allow apps to have a '-' in their name

### DIFF
--- a/scripts/install_apps.ps1
+++ b/scripts/install_apps.ps1
@@ -12,7 +12,7 @@ if ($apps_string) {
 }
 WriteSetupScoopLog "apps: ${apps}"
 foreach($app in $apps) {
-    if ($app -inotmatch "^\w[\w/.@]+$") {
+    if ($app -inotmatch "^\w[\w/.@-]+$") {
         Write-Error "Illegal app name `"$app`"." -ErrorAction Stop
     }
     WriteSetupScoopLog "Installing `"${app}`""


### PR DESCRIPTION
Many apps have a dash in their name. For example: https://scoop.sh/#/apps?q=clang&id=430a8bf29e6c4cbf98cb9e150aa76e663133c6ed