### PR TITLE
fix: correct typo in error message

### DIFF
--- a/.github/workflows/_edge_case.yml
+++ b/.github/workflows/_edge_case.yml
@@ -176,7 +176,7 @@ jobs:
         shell: pwsh
         run: |
           if([bool](scoop bucket list | Select-String -Quiet "extras")) {
-            Write-Error "Unexepected extras bucket found." -ErrorAction Stop
+            Write-Error "Unexpected extras bucket found." -ErrorAction Stop
           }
 
   add_nonportable_bucket:


### PR DESCRIPTION
Fixes #122.

## What
Corrected a typo in the  workflow where 'Unexepected' was spelled incorrectly.

## Why
Ensures error messages are professionally formatted and grammatically correct.

## How
Replaced 'Unexepected' with 'Unexpected' on line 179.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a spelling error in error messaging that users may encounter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->