### PR TITLE
fix: update_PATH_only can't point out explicitly if unexpected PATH.

### DIFF
--- a/.github/workflows/_typical_usage.yml
+++ b/.github/workflows/_typical_usage.yml
@@ -211,7 +211,11 @@ jobs:
       - name: Confirm PATH and scoop is unavailable.
         shell: pwsh
         run: |
-          ($Env:Path -match "scoop")
+          if ($Env:Path -notmatch "scoop") {
+            Write-Error `
+              "PATH environment variable doesn't include path to scoop." `
+              -ErrorAction Stop
+          }
           if(Get-Command scoop -ErrorAction SilentlyContinue) {
             Write-Error "Unexpectedly found scoop." -ErrorAction Stop
           }


### PR DESCRIPTION
Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI validation with stricter error handling: the workflow now fails explicitly when required environment conditions or tools are missing, preventing silent skips.
  * Improves reliability of deployment checks by turning certain precondition checks into hard failures and providing clearer error reporting for missing prerequisites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->