### PR TITLE
fix: Warnings by `PSScriptAnalyzer`. (#129)

### DIFF
--- a/.github/workflows/_edge_case.yml
+++ b/.github/workflows/_edge_case.yml
@@ -173,7 +173,10 @@ jobs:
         shell: pwsh
 
   # `run_as_admin` tests.
-  GitHub_default_runner_without_RunAsAdmin:
+  # Latest install script of scoop has workaround for GitHub Actions,
+  # so RunAsAdmin isn't necessary
+  # to install to GitHub Actions default Windows runner.
+  GitHub_default_runner_doesnt_need_RunAsAdmin:
     needs: validate_inputs_target
 
     strategy:
@@ -186,38 +189,30 @@ jobs:
       - if: inputs.target == 'pr'
         uses: actions/checkout@v6
 
-      - id: pr
-        if: inputs.target == 'pr'
+      - if: inputs.target == 'pr'
         name: Run actions locally
         uses: ./
         with:
           run_as_admin: false
-        continue-on-error: true
 
-      - id: dev
-        if: inputs.target == 'dev'
+      - if: inputs.target == 'dev'
         uses: MinoruSekine/setup-scoop@main
         with:
           run_as_admin: false
-        continue-on-error: true
 
-      - id: release
-        if: inputs.target == 'release'
+      - if: inputs.target == 'release'
         uses: MinoruSekine/setup-scoop@v4.0.2
         with:
           run_as_admin: false
-        continue-on-error: true
 
-      - if: >-
-          ${{
-            steps.pr.outcome == 'success' ||
-            steps.dev.outcome == 'success' ||
-            steps.release.outcome == 'success'
-          }}
-        run: >-
-          Write-Error "${{ github.job }} hasn't been prevented."
-          -ErrorAction Stop
+      - name: Confirm scoop is installed without RunAsAdmin
         shell: pwsh
+        run: |
+          scoop --version
+          if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+            Write-Error "scoop was not installed when run_as_admin=false." `
+            -ErrorAction Stop
+          }
 
   # Obsoleted parameters tests.
   add_extras_bucket:

--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@
 ### `run_as_admin`
 
 - If `true` (default), `scoop` will be installed with option `-RunAsAdmin`
-  - Windows Runners provided by GitHub may need this,
-    because currently they run with Administrator privilege
 - If `false`, `scoop` will be installed without option `-RunAsAdmin`
+- Now both `true` or `false` will work on Windows Runners provided by GitHub,
+  because latest installer of scoop has workaround
+  for GitHub Actions and admin privilege
+  - The `false` value is still meaningful
+    for self-hosted Windows runner without administrator privilege
 
 ### `buckets`
 

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
       run: |
         if('${{ inputs.install_scoop }}' -eq 'true') {
             if('${{ inputs.run_as_admin }}' -eq 'true') {
-                ${{ env.SCRIPTS_PATH }}\install_scoop.ps1 -RunAsAdmin
+                ${{ env.SCRIPTS_PATH }}\install_scoop.ps1 -ForceAdmin
             } else {
                 ${{ env.SCRIPTS_PATH }}\install_scoop.ps1
             }

--- a/scripts/LogModule/LogModule.psm1
+++ b/scripts/LogModule/LogModule.psm1
@@ -1,3 +1,3 @@
 Function WriteSetupScoopLog([string]$LogMessage) {
-    Write-Host setup-scoop: $LogMessage
+    Write-Information "setup-scoop: $LogMessage" -InformationAction Continue
 }

--- a/scripts/install_scoop.ps1
+++ b/scripts/install_scoop.ps1
@@ -1,6 +1,8 @@
-param([switch]$RunAsAdmin)
-if ($RunAsAdmin) {
-    iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+param([switch]$ForceAdmin)
+
+$install_script = [scriptblock]::Create((Invoke-RestMethod -Uri https://get.scoop.sh))
+if ($ForceAdmin) {
+    & $install_script -RunAsAdmin
 } else {
-    irm get.scoop.sh | iex
+    & $install_script
 }


### PR DESCRIPTION
Closes #129 and #132 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that both `run_as_admin: true` and `run_as_admin: false` are supported on GitHub Actions Windows runners due to a workaround in the latest Scoop installer.
  * Added clarification that `run_as_admin: false` remains meaningful for self-hosted Windows runners lacking administrator privilege.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->