### PR TITLE
refactoring: Functions definitions.

### DIFF
--- a/scripts/AppNameModule/AppNameModule.Tests.ps1
+++ b/scripts/AppNameModule/AppNameModule.Tests.ps1
@@ -1,4 +1,4 @@
-Describe 'IsAppNameValid' {
+Describe 'Test-AppName' {
     $modulePath = Join-Path $PSScriptRoot "AppNameModule.psm1"
     Import-Module $modulePath -Force
 
@@ -11,7 +11,7 @@ Describe 'IsAppNameValid' {
             throw "No app names were discovered from 'scoop search'."
          }
         It 'Validation should pass for <Name>' -ForEach $apps {
-            $result = IsAppNameValid $Name
+            $result = Test-AppName $Name
 
             if ($result -eq $false) {
                 Write-Warning "Validation failed for app: [$Name]"
@@ -28,14 +28,14 @@ Describe 'IsAppNameValid' {
             @{ name = "Foo-Bar" }
             @{ name = "g" }
         ) {
-            IsAppNameValid $name | Should -Be $true
+            Test-AppName $name | Should -Be $true
         }
         It 'App name <name> should be invalid' -ForEach @(
             @{ name = "-foo" }
             @{ name = "foo*bar" }
             @{ name = "foo`n" }
         ) {
-            IsAppNameValid $name | Should -Be $false
+            Test-AppName $name | Should -Be $false
         }
     }
 }

--- a/scripts/AppNameModule/AppNameModule.psm1
+++ b/scripts/AppNameModule/AppNameModule.psm1
@@ -1,3 +1,6 @@
-Function IsAppNameValid([string]$AppName) {
+function Test-AppName {
+    param(
+        [string]$AppName
+    )
     return $AppName -imatch "\A\w[\w/.@-]*\z"
 }

--- a/scripts/AppNameModule/AppNameModule.psm1
+++ b/scripts/AppNameModule/AppNameModule.psm1
@@ -1,5 +1,8 @@
 function Test-AppName {
+    [CmdletBinding()]
+    [OutputType([bool])]
     param(
+        [Parameter(Mandatory = $true)]
         [string]$AppName
     )
     return $AppName -imatch "\A\w[\w/.@-]*\z"

--- a/scripts/LogModule/LogModule.psm1
+++ b/scripts/LogModule/LogModule.psm1
@@ -1,3 +1,6 @@
-Function WriteSetupScoopLog([string]$LogMessage) {
+function Write-SetupScoopLog {
+    param(
+        [string]$LogMessage
+    )
     Write-Information "setup-scoop: $LogMessage" -InformationAction Continue
 }

--- a/scripts/LogModule/LogModule.psm1
+++ b/scripts/LogModule/LogModule.psm1
@@ -1,5 +1,7 @@
 function Write-SetupScoopLog {
+    [CmdletBinding()]
     param(
+        [Parameter(Mandatory = $true)]
         [string]$LogMessage
     )
     Write-Information "setup-scoop: $LogMessage" -InformationAction Continue

--- a/scripts/add_buckets.ps1
+++ b/scripts/add_buckets.ps1
@@ -2,19 +2,19 @@ param([string]$buckets_string)
 
 Import-Module "$($PSScriptRoot)\LogModule"
 
-WriteSetupScoopLog "parameter: ${buckets_string}"
+Write-SetupScoopLog "parameter: ${buckets_string}"
 [string[]] $buckets = @()
 if ($buckets_string) {
     $buckets = $buckets_string.Split(" ")
 }
-WriteSetupScoopLog "buckets: ${buckets}"
+Write-SetupScoopLog "buckets: ${buckets}"
 if ($buckets.count -ge 1) {
     $known_buckets=scoop bucket known
     foreach($bucket in $buckets) {
         if($null -eq ($known_buckets | Where-Object {$_ -eq $bucket})) {
             Write-Error "Bucket `"$bucket`" is unknown." -ErrorAction Stop
         }
-        WriteSetupScoopLog "Adding `"${bucket}`" bucket"
+        Write-SetupScoopLog "Adding `"${bucket}`" bucket"
         & scoop bucket add $bucket
     }
 }

--- a/scripts/entry_point.ps1
+++ b/scripts/entry_point.ps1
@@ -11,14 +11,14 @@ if($env:INSTALL_SCOOP -eq 'true') {
 if($env:UPDATE_PATH -eq 'true') {
     Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 }
-WriteSetupScoopLog "env:BUCKETS $env:BUCKETS"
+Write-SetupScoopLog "env:BUCKETS $env:BUCKETS"
 if ($env:BUCKETS) {
     & "$($PSScriptRoot)\add_buckets.ps1" "$env:BUCKETS"
 }
 if($env:SCOOP_UPDATE -eq 'true') { & scoop update }
 if($env:SCOOP_CHECKUP -eq 'true') { & scoop checkup }
-WriteSetupScoopLog "env:APPS $env:APPS"
+Write-SetupScoopLog "env:APPS $env:APPS"
 if ($env:APPS) {
-    WriteSetupScoopLog "Calling install_apps.ps1..."
+    Write-SetupScoopLog "Calling install_apps.ps1..."
     & "$($PSScriptRoot)\install_apps.ps1" "$env:APPS"
 }

--- a/scripts/install_apps.ps1
+++ b/scripts/install_apps.ps1
@@ -6,16 +6,16 @@ param(
 Import-Module "$($PSScriptRoot)\LogModule"
 Import-Module "$($PSScriptRoot)\AppNameModule"
 
-WriteSetupScoopLog "parameter: ${apps_string}"
+Write-SetupScoopLog "parameter: ${apps_string}"
 [string[]] $apps = @()
 if ($apps_string) {
     $apps = $apps_string.Split(" ")
 }
-WriteSetupScoopLog "apps: ${apps}"
+Write-SetupScoopLog "apps: ${apps}"
 foreach($app in $apps) {
-    if (-not (IsAppNameValid $app)) {
+    if (-not (Test-AppName $app)) {
         Write-Error "Illegal app name `"$app`"." -ErrorAction Stop
     }
-    WriteSetupScoopLog "Installing `"${app}`""
+    Write-SetupScoopLog "Installing `"${app}`""
     & scoop install $app
 }


### PR DESCRIPTION
- Use param() block for parameter(s)
- Modified functions' names to Verb-Noun style

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated function names to follow PowerShell naming conventions for improved consistency and discoverability. Functions `IsAppNameValid` and `WriteSetupScoopLog` have been renamed to `Test-AppName` and `Write-SetupScoopLog` respectively. All dependent scripts updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->