### PR TITLE
ci: Replace test target app "doxygen" to "jq" for ci stability.

### DIFF
--- a/.github/workflows/_typical_usage.yml
+++ b/.github/workflows/_typical_usage.yml
@@ -126,7 +126,7 @@ jobs:
   # Install apps check
   install_apps:
     env:
-      TEST_TARGET_APPS: "doxygen fclones xh"
+      TEST_TARGET_APPS: "fclones jq xh"
 
     strategy:
       matrix:


### PR DESCRIPTION
Sometimes doxygen download site returns 403 Forbidden error. It causes CI errors, and it is necessary to recognize who causes errors, setup-scoop codes or other reasons.

Closes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to modify testing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->