### PR TITLE
feat: Clarify supported runners. (#178)

### DIFF
--- a/.github/workflows/_edge_case.yml
+++ b/.github/workflows/_edge_case.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -127,7 +127,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -175,7 +175,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -228,7 +228,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/_typical_usage.yml
+++ b/.github/workflows/_typical_usage.yml
@@ -19,7 +19,7 @@ jobs:
   default:
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -78,7 +78,7 @@ jobs:
   add_extras_bucket_by_buckets_parameter:
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -114,7 +114,7 @@ jobs:
   add_multiple_buckets_at_once:
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -162,7 +162,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -207,7 +207,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -282,7 +282,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 
@@ -323,7 +323,7 @@ jobs:
   update_PATH_only:
     strategy:
       matrix:
-        os: [windows-2025, windows-latest]
+        os: [windows-2025, windows-2022, windows-11-arm]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 ## Supported environments
 
 - `windows-2025`
-- `windows-latest`
+- `windows-2022`
+- `windows-11-arm`
 
 ## Parameters
 


### PR DESCRIPTION
Closes #178

- Replace `windows-latest` to explicitly specifying `windows-2025`
- Add CI for `windows-2022` and `windows-11-arm`
- Update `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test matrix to validate functionality across Windows 2025, Windows 2022, and Windows 11 ARM platforms.

* **Documentation**
  * Updated supported environments list to reflect newly tested Windows versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->