### PR TITLE
ci: Limit `max-parallel` for HTTP 429 error from GitHub.

### DIFF
--- a/.github/workflows/_edge_case.yml
+++ b/.github/workflows/_edge_case.yml
@@ -34,6 +34,7 @@ jobs:
     needs: validate_inputs_target
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -75,6 +76,7 @@ jobs:
     needs: validate_inputs_target
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -126,6 +128,7 @@ jobs:
     needs: validate_inputs_target
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -174,6 +177,7 @@ jobs:
     needs: validate_inputs_target
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -227,6 +231,7 @@ jobs:
     needs: validate_inputs_target
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 

--- a/.github/workflows/_typical_usage.yml
+++ b/.github/workflows/_typical_usage.yml
@@ -18,6 +18,7 @@ jobs:
   # Typical usage
   default:
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -57,6 +58,7 @@ jobs:
     if: inputs.target == 'pr'
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -77,6 +79,7 @@ jobs:
   # `buckets` parameter check
   add_extras_bucket_by_buckets_parameter:
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -113,6 +116,7 @@ jobs:
 
   add_multiple_buckets_at_once:
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -161,6 +165,7 @@ jobs:
       # yamllint enable rule:line-length
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -206,6 +211,7 @@ jobs:
       TEST_TARGET_APPS: MinoruSekineLocal/win-toast-cli
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -281,6 +287,7 @@ jobs:
       TEST_TARGET_APPS: "fclones jq xh"
 
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 
@@ -322,6 +329,7 @@ jobs:
   # `update_path` without installing scoop, any buckets, and any apps
   update_PATH_only:
     strategy:
+      max-parallel: 1
       matrix:
         os: [windows-2025, windows-2022, windows-11-arm]
 


### PR DESCRIPTION
https://github.com/MinoruSekine/setup-scoop/actions/runs/28969737069/job/85962052778#step:5:33

```
Invoke-RestMethod: D:\a\_actions\MinoruSekine\setup-scoop\v5\scripts\install_scoop.ps1:12 Line |
  12 |  …  [scriptblock]::Create((Invoke-RestMethod -Uri https://get.scoop.sh))
     |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | 429: Too Many Requests For more on scraping GitHub and how it may affect your rights, please review our Terms of
     | Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service).
Error: Process completed with exit code 1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Limited parallel execution for workflow test scenarios to improve reliability and consistency.
  * Preserved existing validation steps, inputs, and behavior while serializing matrix runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->