### PR TITLE
fix: No errors by download scoop install script failure (#193)

### DIFF
--- a/scripts/install_scoop.ps1
+++ b/scripts/install_scoop.ps1
@@ -17,6 +17,9 @@ if ($SkipIfAvailable -and (Get-Command "scoop")) {
 # That makes difficult to trap errors.
 $installerPath = Join-Path $env:RUNNER_TEMP "install-scoop.ps1"
 Invoke-RestMethod -Uri https://get.scoop.sh -OutFile $installerPath
+if (-not $?) {
+    Write-Error "Failed to download 'scoop' install script." -ErrorAction Stop
+}
 
 if ($ForceAdmin) {
     Invoke-External $installerPath "-RunAsAdmin"


### PR DESCRIPTION
Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Scoop installation reliability by detecting failed installer-script downloads and stopping with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->