### PR TITLE
fix: Fast-fail on non-Windows runner. (#194)

### DIFF
--- a/scripts/entry_point.ps1
+++ b/scripts/entry_point.ps1
@@ -1,5 +1,8 @@
 Import-Module (Join-Path $($PSScriptRoot) "modules/Invoke-External")
 
+# Fail fast by unsupported runner.
+Invoke-External -Command "$($PSScriptRoot)\test_runner_os.ps1"
+
 # Fail fast by unsupported Action parameter(s).
 Invoke-External -Command "$($PSScriptRoot)\test_action_params.ps1"
 

--- a/scripts/test_runner_os.ps1
+++ b/scripts/test_runner_os.ps1
@@ -1,0 +1,20 @@
+Import-Module (Join-Path $($PSScriptRoot) "modules/Write-SetupScoopLog")
+
+function Test-RunnerOS {
+    if (-not $env:RUNNER_OS) {
+        Write-Error "Environment variable RUNNER_OS is not set." `
+          -ErrorAction Stop
+    }
+
+    if ($env:RUNNER_OS -ne "Windows") {
+        Write-Error @"
+setup-scoop supports only Windows runner.
+RUNNER_OS is `"$($env:RUNNER_OS)`."
+"@ `
+          -ErrorAction Stop
+    }
+
+    Write-SetupScoopLog "RUNNER_OS `"$($env:RUNNER_OS)`" is supported."
+}
+
+Test-RunnerOS


### PR DESCRIPTION
Closes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early environment check to prevent setup from continuing on unsupported operating systems.
  * Windows runner validation now fails fast with a clear error when the environment is not supported.
  * Supported Windows environments are logged before setup proceeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->